### PR TITLE
Replace parameters with associated values and update result

### DIFF
--- a/Nora/DatabaseProvider.swift
+++ b/Nora/DatabaseProvider.swift
@@ -66,20 +66,15 @@ public class DatabaseProvider<Target: DatabaseTarget> {
         }
         
         switch request.task {
-        case .setValue:
+        case .setValue(let value):
             
             if request.onDisconnect {
-                request.reference.onDisconnectSetValue(request.parameters, withCompletionBlock: completionBlock)
+                request.reference.onDisconnectSetValue(value, withCompletionBlock: completionBlock)
             } else {
-                request.reference.setValue(request.parameters, withCompletionBlock: completionBlock)
+                request.reference.setValue(value, withCompletionBlock: completionBlock)
             }
             
-        case .updateChildValues:
-            
-            guard let values = request.parameters else {
-                completion(.failure(NoraError.invalidParameters))
-                break
-            }
+        case .updateChildValues(let values):
             
             if request.onDisconnect {
                 request.reference.onDisconnectUpdateChildValues(values, withCompletionBlock: completionBlock)
@@ -122,7 +117,7 @@ private extension DatabaseProvider {
             return .success(response)
         case let (.some(snapshot), .some(reference), .none, _):
             let response = DatabaseResponse(reference: reference, snapshot: snapshot, isCommitted: true)
-            return snapshot.exists() ? .success(response) : .failure(NoraError.nullSnapshot)
+            return .success(response)
         case let (.none, .some(reference), .none, _):
             let response = DatabaseResponse(reference: reference, isCommitted: true)
             return .success(response)

--- a/Nora/DatabaseResponse.swift
+++ b/Nora/DatabaseResponse.swift
@@ -11,7 +11,6 @@ import FirebaseDatabase
 
 // MARK: - DatabaseResponse
 
-
 public struct DatabaseResponse {
     
     public let snapshot: FIRDataSnapshot?

--- a/Nora/FirebaseTarget.swift
+++ b/Nora/FirebaseTarget.swift
@@ -23,9 +23,6 @@ public protocol DatabaseTarget {
     /// Type of task you want to perform ( Firebase method: eg. observe, observeOnce, setValue, etc. )
     var task: DatabaseTask { get }
     
-    /// Values to write for a upload request
-    var parameters: [String: Any]? { get }
-    
     /// Transaction block to run for .transaction task ( Defaults to FIRTransactionResult.success(withValue: FIRMutableData) )
     var transactionBlock: (FIRMutableData) -> FIRTransactionResult { get }
     
@@ -70,4 +67,17 @@ public protocol StorageTarget {
     /// Type of task you want to perform ( Firebase storage method: eg. put, putFile, write, delete )
     var task: StorageTask { get }
     
+}
+
+// MARK: - FirebaseTarget
+
+public protocol FirebaseTarget {}
+
+public extension FirebaseTarget {
+
+    /// Generate unique id String
+    func uniqueID() -> String {
+        return UUID().uuidString.lowercased()
+    }
+
 }

--- a/Nora/FirebaseTask.swift
+++ b/Nora/FirebaseTask.swift
@@ -17,8 +17,8 @@ public enum DatabaseTask {
     
     case observe(FIRDataEventType)
     case observeOnce(FIRDataEventType)
-    case setValue
-    case updateChildValues
+    case setValue(Any?)
+    case updateChildValues([AnyHashable: Any])
     case removeValue
     case transaction
     

--- a/Nora/NoraError.swift
+++ b/Nora/NoraError.swift
@@ -11,11 +11,7 @@ import Foundation
 // MARK: - NoraError
 
 public enum NoraError: Error {
-    case nullSnapshot
-    case invalidParameters
     case resultConversion
     case requestMapping
-    case jsonMapping
-    case objectDecoding
     case underlying(Error)
 }

--- a/Nora/Request.swift
+++ b/Nora/Request.swift
@@ -16,7 +16,6 @@ struct DatabaseRequest {
     
     var reference: FIRDatabaseReference
     var task: DatabaseTask
-    var parameters: [String: Any]?
     var transactionBlock: (FIRMutableData) -> FIRTransactionResult
     var onDisconnect: Bool
     var localEvents: Bool
@@ -28,7 +27,6 @@ extension DatabaseRequest {
     init(_ target: DatabaseTarget) {
         self.reference = target.baseReference.child(target.path)
         self.task = target.task
-        self.parameters = target.parameters
         self.transactionBlock = target.transactionBlock
         self.onDisconnect = target.onDisconnect
         self.localEvents = target.localEvents

--- a/Nora/Result.swift
+++ b/Nora/Result.swift
@@ -12,7 +12,7 @@ import Foundation
 
 public enum Result<Value> {
     case success(Value)
-    case failure(Error?)
+    case failure(Error)
 }
 
 public extension Result {
@@ -21,7 +21,7 @@ public extension Result {
         self = .success(value)
     }
     
-    init(error: Error?) {
+    init(error: Error) {
         self = .failure(error)
     }
     


### PR DESCRIPTION
### API BREAKING
- change `Result.failure` error? to non-optional value, close #1
- remove `parameters` property from `DatabaseTarget`
Instead use associated values for `setValue(Any?)` and `updateChildValues([AnyHashable: Any])`
This results in a nicer API for the user and them not having to return a nil value for read requests

### Enhancements
- removed defaulting an empty `FIRDataSnapshot` to a `Result.failure`
Reasoning: Users may want to retrieve an empty snapshot to check if data exists
- added a `func uniqueID() -> String` method to `FirebaseTarget` types
Reasoning: Convenient way for users to make unique paths like Firebase's `childByAutoId()`