### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simply put, working with Firebase just got whole lot easier.
 
 ## Installation
 
-Firebase is currently shipped as a static framework - which prevents Nora from having Cocoapods support.
+Firebase is currently shipped as a static framework - which prevents Nora from having CocoaPods support.
 
 Don't fret though! This just means the installation process is even simpler!
 
@@ -45,7 +45,7 @@ Open the Nora.xcodeproj project and drag the `Sources` folder into your App
 
 ### Step 3
 
-Download Nora's dependencies using Cocoapods. Add them to your podfile
+Download Nora's dependencies using CocoaPods. Add them to your podfile
 
 ```rb
 


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).
