### PR TITLE
Add DatabaseResponse decoding methods

### DIFF
--- a/Nora/DatabaseProvider.swift
+++ b/Nora/DatabaseProvider.swift
@@ -15,6 +15,10 @@ public typealias JSON = [String: Any]
 
 public class DatabaseProvider<Target: DatabaseTarget> {
     
+    /// Make a request to FirebaseDatabase
+    /// - Parameter target: target for the request
+    /// - Parameter completion: completion block with result of the request
+    /// - Returns: a handle in the case of an observe request, used to deregister the observer (optional)
     @discardableResult
     public func request(_ target: Target, completion: @escaping DatabaseCompletion) -> UInt? {
         

--- a/Nora/DatabaseResponse.swift
+++ b/Nora/DatabaseResponse.swift
@@ -9,6 +9,14 @@
 import Foundation
 import FirebaseDatabase
 
+// MARK: - JSONDecodeable
+
+public protocol JSONDecodeable {
+
+    init?(_ json: JSON)
+
+}
+
 // MARK: - DatabaseResponse
 
 public struct DatabaseResponse {
@@ -24,6 +32,78 @@ public extension DatabaseResponse {
         self.reference = reference
         self.snapshot = snapshot
         self.isCommitted = isCommitted
+    }
+    
+}
+
+// MARK: - Response Decoding
+
+public extension DatabaseResponse {
+
+    /// The FIRDataSnapshot of the response as JSON
+    var json: [String: Any]? {
+        return snapshot?.value as? JSON
+    }
+    
+    /// Decode the FIRDataSnapshot to a JSONDecodeable type
+    /// - Parameter transform: closure that takes in JSON and returns a JSONDecodeable type
+    /// - Returns: decoded object
+    public func mapTo<T: JSONDecodeable>(_ transform: (JSON) -> T?) throws -> T {
+        
+        guard let snapshot = snapshot, snapshot.exists() else {
+            throw NoraError.nullSnapshot
+        }
+        
+        guard let json = snapshot.value as? JSON else {
+            throw NoraError.jsonMapping
+        }
+        
+        guard let result = T(json) else {
+            throw NoraError.objectDecoding
+        }
+        
+        return result
+        
+    }
+    
+    /// Convert the children of a FIRDataSnapshot to JSON
+    public func childrenAsJSON() throws -> [JSON] {
+        
+        guard let snapshot = snapshot, snapshot.exists() else {
+            throw NoraError.nullSnapshot
+        }
+        
+        var result: [JSON] = []
+        
+        for child in snapshot.children {
+            guard let snapshot = child as? FIRDataSnapshot, let json = snapshot.value as? JSON else {
+                throw NoraError.jsonMapping
+            }
+            
+            result.append(json)
+        }
+        
+        return result
+        
+    }
+    
+    /// Decode the children of FIRDataSnapshot to a JSONDecodeable type
+    /// - Parameter transform: a closure taking in JSON and returning a JSONDecodeable type
+    /// - Returns: an array of decoded objects
+    public func mapChildrenTo<T: JSONDecodeable>(_ transform: (JSON) -> T?) throws -> [T] {
+        
+        let childJSON = try childrenAsJSON()
+        
+        var result: [T] = []
+        
+        for json in childJSON {
+            guard let decoded = transform(json) else {
+                throw NoraError.objectDecoding
+            }
+            result.append(decoded)
+        }
+        
+        return result
     }
     
 }

--- a/Nora/NoraError.swift
+++ b/Nora/NoraError.swift
@@ -11,7 +11,39 @@ import Foundation
 // MARK: - NoraError
 
 public enum NoraError: Error {
+    
     case resultConversion
+    
     case requestMapping
+    
+    case nullSnapshot
+    
+    case jsonMapping
+    
+    case objectDecoding
+    
     case underlying(Error)
+    
+}
+
+// MARK: - LocalizedError
+
+extension NoraError: LocalizedError {
+
+    public var errorDescription: String? {
+        switch self {
+        case .resultConversion:
+            return "There was an error converting the Response to a Result."
+        case .requestMapping:
+            return "There was an error mapping the Request to Firebase."
+        case .nullSnapshot:
+            return "The FIRDataSnapshot is empty."
+        case .jsonMapping:
+            return "The FIRDataSnapshot to JSON conversion failed."
+        case .objectDecoding:
+            return "The object decoding for the Response failed."
+        case .underlying(let error):
+            return error.localizedDescription
+        }
+    }
 }


### PR DESCRIPTION
## Enhancements
This Pull Request adds basic methods for handling the `DatabaseResponse`

### Properties
`response.json -> [String: Any]`

### Methods
`func mapTo<T: JSONDecodeable>(_ transform: (JSON) -> T?) throws -> T`
`func childrenAsJSON() throws -> [JSON]`
`mapChildrenTo<T: JSONDecodeable>(_ transform: (JSON) -> T?) throws -> [T]`

### NoraError
- Added conformance to `LocalizedError` for more descriptive `Error` messages