### PR TITLE
[#10] fix travis

### DIFF
--- a/Nora.xcodeproj/xcshareddata/xcschemes/Nora.xcscheme
+++ b/Nora.xcodeproj/xcshareddata/xcschemes/Nora.xcscheme
@@ -20,6 +20,34 @@
                ReferencedContainer = "container:Nora.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C052BEBFBD0AB5218CC64BA3450F6547"
+               BuildableName = "GTMSessionFetcher.framework"
+               BlueprintName = "GTMSessionFetcher"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "00103D6C821BE85971C563025527BA5D"
+               BuildableName = "GoogleToolboxForMac.framework"
+               BlueprintName = "GoogleToolboxForMac"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ time xcodebuild clean test \
     -scheme 'Nora' \
     -sdk iphonesimulator \
     -derivedDataPath $DERIVED_DATA \
-    -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
+    -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.2' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \
     | tee build.log \
     | xcpretty &&

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ rm -rf $DERIVED_DATA &&
 time xcodebuild clean test \
     -workspace Nora.xcworkspace \
     -scheme 'Nora' \
-    -sdk iphonesimulator10.2 \
+    -sdk iphonesimulator \
     -derivedDataPath $DERIVED_DATA \
-    -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.2' \
+    -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3' \
     OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-function-bodies' \
     | tee build.log \
     | xcpretty &&


### PR DESCRIPTION
Should be passing now. Problem was that you were not linking pod dependencies for xcodebuild. I am not sure but I think you could reconsider using cocoapods for dependencies management. Doing so probably makes it impossible for people not using cocoapods to use your lib. Carthage is more lightweight tool for it since it only fetched the binary dependencies build and does not change your xcode project settings at all.