### PR TITLE
Use baseReference when String path is empty #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# CHANGELOG
+All notable changes to this project will be documented in this file. 
+`Nora` adheres to [Semantic Versioning](http://semver.org/).
+
+---
+
+## Versions
+
+---
+
+### Next Version
+
+### API Breaking Changes
+N/A
+
+### Enhancements
+N/A
+
+### Bugfixes
+N/A
+
+---
+
+### [0.1.1](https://github.com/SD10/Nora/releases/tag/0.1.0)
+
+### Bugfixes
+- Empty `String` path for `DatabaseTarget` & `StorageTarget` now uses `baseReference`. [#20](https://github.com/SD10/Nora/pull/20) by [@SD10](https://github.com/SD10)
+
+---
+
+### [0.1.0 Pre-Release](https://github.com/SD10/Nora/releases/tag/0.1.0)
+- Initial Release
+

--- a/Nora.xcodeproj/project.pbxproj
+++ b/Nora.xcodeproj/project.pbxproj
@@ -122,8 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				B062C7091E947363006C3CB8 /* Sources */,
-				B062C6D31E946B59006C3CB8 /* Info.plist */,
-				B062C6D21E946B59006C3CB8 /* Nora.h */,
+				B0FF35661EC6E7C8005C5F62 /* Supporting */,
 			);
 			path = Nora;
 			sourceTree = "<group>";
@@ -143,6 +142,15 @@
 				B0602A3B1E98F03D0087BBD9 /* NoraError.swift */,
 			);
 			name = Sources;
+			sourceTree = "<group>";
+		};
+		B0FF35661EC6E7C8005C5F62 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				B062C6D31E946B59006C3CB8 /* Info.plist */,
+				B062C6D21E946B59006C3CB8 /* Nora.h */,
+			);
+			name = Supporting;
 			sourceTree = "<group>";
 		};
 		FCE6F04A38E4E8B62D9181C9 /* Frameworks */ = {

--- a/Nora/DatabaseRequest.swift
+++ b/Nora/DatabaseRequest.swift
@@ -24,7 +24,7 @@ struct DatabaseRequest {
 extension DatabaseRequest {
     
     init(_ target: DatabaseTarget) {
-        self.reference = target.baseReference.child(target.path)
+        self.reference = target.path == "" ? target.baseReference : target.baseReference.child(target.path)
         self.task = target.task
         self.transactionBlock = target.transactionBlock
         self.onDisconnect = target.onDisconnect
@@ -44,7 +44,7 @@ struct DatabaseQueryRequest {
 extension DatabaseQueryRequest {
     
     init(_ target: DatabaseTarget) {
-        let reference = target.baseReference.child(target.path)
+        let reference = target.path == "" ? target.baseReference : target.baseReference.child(target.path)
         self.query = target.queries?.reduce(reference) { $1.prepare($0) } ?? reference
         self.task = target.task
     }

--- a/Nora/StorageRequest.swift
+++ b/Nora/StorageRequest.swift
@@ -21,7 +21,7 @@ struct StorageRequest {
 extension StorageRequest {
     
     init(_ target: StorageTarget) {
-        self.reference = target.baseReference.child(target.path)
+        self.reference = target.path == "" ? target.baseReference : target.baseReference.child(target.path)
         self.task = target.task
     }
     

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
  </p>
  
  <p align="center">
+     <a href="https://codebeat.co/projects/github-com-sd10-nora-master">
+         <img src="https://codebeat.co/badges/222038d6-dd5d-4253-94a6-63f00d3a1ae9" 
+              alt="codebeat badge">
+     </a>
      <a href="https://travis-ci.org/SD10/Nora">
          <img src="https://travis-ci.org/SD10/Nora.svg?branch=master"
               alt="Build Status">


### PR DESCRIPTION
### Summary of Pull Request:
- Implements the changes discussed in #19 
- If `path` property of `DatabaseTarget` or `StorageTarget` is an empty `String`, a child path will not be applied and the baseReference will be used instead. 