### PR TITLE
Fix error "'NRDatabaseProvider<Target>' initializer is inaccessible d…

### DIFF
--- a/Sources/NRDatabaseProvider.swift
+++ b/Sources/NRDatabaseProvider.swift
@@ -13,8 +13,8 @@ import Result
 public typealias DatabaseCompletion = (Result<NRDatabaseResponse, NRError>) -> Void
 public typealias TransactionBlock = (MutableData) -> TransactionResult
 
-public class NRDatabaseProvider<Target: NRDatabaseTarget>: NSObject {
-
+public class NRDatabaseProvider<Target: NRDatabaseTarget> {
+  
     /// Make a request to FirebaseDatabase
     /// - Parameter target: target for the request
     /// - Parameter completion: completion block with result of the request

--- a/Sources/NRDatabaseProvider.swift
+++ b/Sources/NRDatabaseProvider.swift
@@ -14,7 +14,9 @@ public typealias DatabaseCompletion = (Result<NRDatabaseResponse, NRError>) -> V
 public typealias TransactionBlock = (MutableData) -> TransactionResult
 
 public class NRDatabaseProvider<Target: NRDatabaseTarget> {
-  
+    
+    /// Default init
+    public init() {}
     /// Make a request to FirebaseDatabase
     /// - Parameter target: target for the request
     /// - Parameter completion: completion block with result of the request

--- a/Sources/NRDatabaseProvider.swift
+++ b/Sources/NRDatabaseProvider.swift
@@ -13,8 +13,8 @@ import Result
 public typealias DatabaseCompletion = (Result<NRDatabaseResponse, NRError>) -> Void
 public typealias TransactionBlock = (MutableData) -> TransactionResult
 
-public class NRDatabaseProvider<Target: NRDatabaseTarget> {
-  
+public class NRDatabaseProvider<Target: NRDatabaseTarget>: NSObject {
+
     /// Make a request to FirebaseDatabase
     /// - Parameter target: target for the request
     /// - Parameter completion: completion block with result of the request

--- a/Sources/NRStorageProvider.swift
+++ b/Sources/NRStorageProvider.swift
@@ -14,6 +14,9 @@ public typealias StorageCompletion = (Result<NRStorageResponse, NRError>) -> Voi
 
 public class NRStorageProvider<Target: NRStorageTarget> {
     
+    /// Default init
+    public init() {}
+    
     @discardableResult
     public func request(_ target: Target, completion: @escaping StorageCompletion) -> StorageObservableTask? {
         


### PR DESCRIPTION
I got this error with Swift 4
`'NRDatabaseProvider<Target>' initializer is inaccessible due to 'internal' protection level`
I solved in this way. 
Am I implemeting on a bad way? 

Thanks